### PR TITLE
Migrate to CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,10 @@ references:
       - run:
           name: Prepare for running tests
           command: |
-            pip install -r requirements.txt
-            pip install codecov coverage
-            pip install -e .
+            pip install --user -r requirements.txt
+            pip install --user codecov coverage
+            touch README.rst
+            pip install --user -e .
       - run:
           name: Run test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ references:
     steps:
       - checkout
       - run:
+          name: Check Python version
+          command: |
+            python -V
+      - run:
           name: Prepare for running tests
           command: |
             pip install --user -r requirements.txt
@@ -15,15 +19,18 @@ references:
           name: Run test
           command: |
             python setup.py test
+            export PATH=$HOME/.local/bin:$PATH
             factordb 1
             factordb --json 16
       - run:
           name: Run coverage
           command: |
+            export PATH=$HOME/.local/bin:$PATH
             coverage run setup.py test
       - run:
           name: Run codecov
           command: |
+            export PATH=$HOME/.local/bin:$PATH
             codecov
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2
+
+references:
+  test_code: &test_code
+    steps:
+      - checkout
+      - run:
+          name: Prepare for running tests
+          command: |
+            pip install -r requirements.txt
+            pip install codecov coverage
+            pip install -e .
+      - run:
+          name: Run test
+          command: |
+            python setup.py test
+            factordb 1
+            factordb --json 16
+      - run:
+          name: Run coverage
+          command: |
+            coverage run setup.py test
+      - run:
+          name: Run codecov
+          command: |
+            codecov
+
+jobs:
+  python2:
+    docker:
+      - image: circleci/python:2.7
+    <<: *test_code
+
+  python3:
+    docker:
+      - image: circleci/python:3
+    <<: *test_code
+
+
+workflows:
+  version: 2
+  test_all_python_versions:
+    jobs:
+      - python2
+      - python3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,24 @@ jobs:
       - image: circleci/python:2.7
     <<: *test_code
 
-  python3:
+  python34:
     docker:
-      - image: circleci/python:3
+      - image: circleci/python:3.4
+    <<: *test_code
+
+  python35:
+    docker:
+      - image: circleci/python:3.5
+    <<: *test_code
+
+  python36:
+    docker:
+      - image: circleci/python:3.6
+    <<: *test_code
+
+  python_latest:
+    docker:
+      - image: circleci/python:latest
     <<: *test_code
 
 
@@ -50,4 +65,7 @@ workflows:
   test_all_python_versions:
     jobs:
       - python2
-      - python3
+      - python34
+      - python35
+      - python36
+      - python_latest


### PR DESCRIPTION
Supports:

+ [ ]  Build and test on some Python versions.
+ [ ] Cache Python cache (fg. `pip install....`)
