### PR TITLE
Disable SSL certificate verification because of ENDPOINT SSL is invalid

### DIFF
--- a/factordb/factordb.py
+++ b/factordb/factordb.py
@@ -15,7 +15,7 @@ class FactorDB():
     def connect(self, reconnect=False):
         if self.result and not reconnect:
             return self.result
-        self.result = requests.get(ENDPOINT, params={"query": str(self.n)})
+        self.result = requests.get(ENDPOINT, params={"query": str(self.n)}, verify=False)
         return self.result
 
     def get_id(self):


### PR DESCRIPTION
https://factordb.com is now available but SSL certificate is expired. This modification is disable for checking SSL validation.