### PR TITLE
Fix endpoint URL not to use https #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to know more detail of result, you can get an answer of JSON format.
 
 ```bash
 $ factordb --json 16
-{"id": "https://factordb.com/?id=2", "status": "FF", "factors": [2, 2, 2, 2]}
+{"id": "http://factordb.com/?id=2", "status": "FF", "factors": [2, 2, 2, 2]}
 ```
 
 ### Library usage

--- a/factordb/cli.py
+++ b/factordb/cli.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import sys
 
-from .factordb import FactorDB
+from .factordb import FactorDB, ENDPOINT
 
 
 def create_parser():
@@ -36,7 +36,7 @@ def main():
 
     if args.json:
         out = {
-            "id": "https://factordb.com/?id={}".format(factordb.get_id()),
+            "id": "{}/?id={}".format(ENDPOINT, factordb.get_id()),
             "status": factordb.get_status(),
             "factors": factordb.get_factor_list(),
         }

--- a/factordb/factordb.py
+++ b/factordb/factordb.py
@@ -4,7 +4,7 @@ from __future__ import print_function, unicode_literals
 import requests
 
 
-ENDPOINT = "https://factordb.com/api"
+ENDPOINT = "http://factordb.com/api"
 
 
 class FactorDB():
@@ -15,7 +15,7 @@ class FactorDB():
     def connect(self, reconnect=False):
         if self.result and not reconnect:
             return self.result
-        self.result = requests.get(ENDPOINT, params={"query": str(self.n)}, verify=False)
+        self.result = requests.get(ENDPOINT, params={"query": str(self.n)})
         return self.result
 
     def get_id(self):


### PR DESCRIPTION
SSL endpoint certificate was expired since December, 2017. 