### PR TITLE
add ability to submit factors.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+pycryptodome

--- a/factordb/factordb.py
+++ b/factordb/factordb.py
@@ -49,3 +49,11 @@ class FactorDB():
             return []
         ml = [[int(x)] * y for x, y in factors]
         return [y for x in ml for y in x]
+
+    @staticmethod
+    def submit_factors(product, factors):
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        factors = map(str, factors)
+        data = {"report": f"{product}={','.join(factors)}"}
+        requests.post("http://factordb.com/report.php", headers=headers, data=data)

--- a/tests/test_factordb.py
+++ b/tests/test_factordb.py
@@ -3,6 +3,7 @@ from __future__ import print_function, unicode_literals
 import unittest
 
 from factordb.factordb import FactorDB
+from Crypto.Util import number
 
 
 class FactorDBTestCase(unittest.TestCase):
@@ -62,6 +63,28 @@ class FactorDBTestCase(unittest.TestCase):
         })
 
         self.assertTrue(factordb.is_prime())
+
+    def test_submit(self):
+        def generate_unfactorised_nums():
+            p = number.getPrime(1024)
+            q = number.getPrime(1024)
+            n = p * q
+
+            factordb = FactorDB(n)
+            factordb.connect()
+
+            if factordb.get_status() == 'C':
+                return n, sorted([p, q])
+
+            return generate_unfactorised_nums()
+
+        n, factors = generate_unfactorised_nums()
+        FactorDB.submit_factors(n, factors)
+
+        factordb = FactorDB(n)
+        factordb.connect(reconnect=True)
+        self.assertEqual(factordb.get_status(), 'FF')
+        self.assertListEqual(factordb.get_factor_list(), factors)
 
     def __check_testcase(self, factordb, expected):
         self.assertEqual(factordb.get_id(), expected['id'])

--- a/tests/test_factordb.py
+++ b/tests/test_factordb.py
@@ -65,7 +65,9 @@ class FactorDBTestCase(unittest.TestCase):
         self.assertTrue(factordb.is_prime())
 
     def test_submit(self):
-        def generate_unfactorised_nums():
+        # generate not yet factorized numbers
+        factordb = None
+        while factordb is None or factordb.get_status() != 'C':
             p = number.getPrime(1024)
             q = number.getPrime(1024)
             n = p * q
@@ -73,15 +75,10 @@ class FactorDBTestCase(unittest.TestCase):
             factordb = FactorDB(n)
             factordb.connect()
 
-            if factordb.get_status() == 'C':
-                return n, sorted([p, q])
-
-            return generate_unfactorised_nums()
-
-        n, factors = generate_unfactorised_nums()
+        # sort numbers because factordb returns them in ascending order
+        factors = sorted([p, q])
         FactorDB.submit_factors(n, factors)
 
-        factordb = FactorDB(n)
         factordb.connect(reconnect=True)
         self.assertEqual(factordb.get_status(), 'FF')
         self.assertListEqual(factordb.get_factor_list(), factors)


### PR DESCRIPTION
closes #12

Please also note there is:
https://github.com/RsaCtfTool/RsaCtfTool/blob/master/lib/fdb.py

I did not use or reference this, because its license might not be compatible with the MIT license of this project. And I also thought it might be faster to just write the code than reading licensing rules.

# Tests
While trying to crack RSA keys, I often noticed even small numbers not being solved.  
I think they could make for good tests.

I decided on 1024 because it used to be a commonly used RSA size.
Atfirst I used 2048, but it had some performance issues with generating the keys.

# Todo
- [x] `pycryptodome` requirement for development.
- [ ] should we do anything with the response.
- [ ] should we check the factors before submitting the values?
- [ ] `submit_factors` as static member, normal member or standalone function?
- [ ] are f-strings ok, or do we support some python versions older than 3.6?